### PR TITLE
Added base_url config for connecting to other OpenAI compatible APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # OpenAI API T2T Component by LCC
 
 ## What is this for?
-Uses [OpenAI's Python SDK](https://github.com/openai/openai-python) to generate responses from text given your configured model. For information on their text generation API, visit [their docs](https://platform.openai.com/docs/guides/text-generation).
+Uses [OpenAI's Python SDK](https://github.com/openai/openai-python) to generate responses from text given your configured model. Also will work with any OpenAI-compatible API.
+
+Examples of compatible providers and servers:
+- [OpenAI](https://platform.openai.com/docs/api-reference/models) (obviously)
+- [Text generation web UI](https://github.com/oobabooga/text-generation-webui)
+- [LM Studio](https://lmstudio.ai)
+- [llama-server](https://github.com/ggml-org/llama.cpp?tab=readme-ov-file#llama-server)
+- [Ollama](https://ollama.com)
+
+
+For information on OpenAI's text generation API, visit [their docs](https://platform.openai.com/docs/guides/text-generation).
 
 ## Setup
 
@@ -28,6 +38,8 @@ You can find you OpenAI API token [here](https://platform.openai.com/api-keys) a
 <img src="./assets/openai_1.png" alt="openai api token location 1" height="200"/>
 <img src="./assets/openai_2.png" alt="openai api token location 2" height="200"/>
 
+If you use a diffenent provider, make sure to set a key as well. Any value is usually ok, if unsure check your LLM server's documentation.
+
 ## Testing
 Assuming you are in the right virtual environment and are in the root directory:
 ```
@@ -37,6 +49,8 @@ If it runs, it should be fine.
 
 ## Configuration
 In `config.json`, update `model` with the model you want to use like `gpt-4o-mini` or `ft:gpt-4o-mini-2024...`. Also update `env` with the filepath to your `.env` environment file.
+
+If you use OpenAI's services, set `base_url` to `https://api.openai.com/v1`. For other providers, check their respective documentation.
 
 Adjust `temperature`, `top_p`, `frequency_penalty`, `presence_penalty` to change variety of responses to your liking.
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "base_url": "https://api.openai.com/v1",
     "model": "ft:gpt-4o-mini-2024-07-18:lcc::B0GEEL0o",
     "temperature": 0.7,
     "top_p": 0.9,

--- a/src/custom/__init__.py
+++ b/src/custom/__init__.py
@@ -13,7 +13,7 @@ You may also simply return the final result
 '''
 
 from .model import OpenAIModel
-t2t_model = OpenAIModel(config['model'],config['temperature'],config['top_p'],config['frequency_penalty'],config['presence_penalty'])
+t2t_model = OpenAIModel(config['base_url'], config['model'],config['temperature'],config['top_p'],config['frequency_penalty'],config['presence_penalty'])
 
 from jaison_grpc.common import STTComponentRequest, T2TComponentRequest, TTSGComponentRequest, TTSCComponentRequest
 async def request_unpacker(request_iterator):

--- a/src/custom/model.py
+++ b/src/custom/model.py
@@ -9,8 +9,8 @@ from openai import OpenAI
 import logging
 
 class OpenAIModel():
-    def __init__(self, model_name, temperature, top_p, frequency_penalty, presence_penalty):
-        self.client = OpenAI()
+    def __init__(self, base_url, model_name, temperature, top_p, frequency_penalty, presence_penalty):
+        self.client = OpenAI(base_url=base_url)
         self.model_name = model_name
         
         self.temperature = temperature


### PR DESCRIPTION
Added base_url to config file and OpenAIModel init. This makes it possible to connect to other providers with an OpenAI compatible API and locally run servers like LM Studio or LLaMA.cpp HTTP Server.